### PR TITLE
fixed array escaping

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -17,18 +17,14 @@ exports.create = function(queryArr, escape) {
       if (util.isString(q)) return s + q;
 
       if (util.isObject(args[0]) && !util.isArray(args[0])) { // direct mapping
-        val = util.wrap(args[0][q.name]);
+        val = util.wrap(args[0][q.name], escape);
       } else {     // one at a time
-        val = util.wrap(args[q.idx]);
+        val = util.wrap(args[q.idx], escape);
       }
 
       if (_.isUndefined(val)) val = null;
 
-      if (_.isFunction(escape)) {
-        return s + escape(val);
-      } else {
-        return s + val;
-      }
+      return s + val;
     }, '');
   };
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,17 +43,21 @@ module.exports = {
   read: function(path) {
     return fs.readFileSync(path, { encoding: 'utf8' });
   },
-  wrap: function(value) {
-    var wrapQuotes = function(v) {
-      if (_.isString(v)) return '"' + v + '"';
 
-      return v;
-    };
+  wrapQuotes: function (v) {
+    if (_.isString(v)) return '"' + v + '"';
 
+    return v;
+  },
+
+  wrap: function (value, escape) {
+    if(!escape) {
+      escape = this.wrapQuotes;
+    }
     if (this.isString(value)) {
-      return wrapQuotes(value);
+      return escape(value);
     } else if (this.isArray(value)) {
-      return '(' + _.map(value, wrapQuotes).toString() + ')';
+      return '(' + _.map(value, v => this.wrap(v, escape)).toString() + ')';
     } else {
       return value;
     }


### PR DESCRIPTION
I noticed the arrays don't get escaped properly if you have an escape function. The wrapQuotes function does map over the elements of the array, so something like `[1, 2, 3]` becomes `"(1, 2, 3)"`. Then the the `escape` function was applied to the result string, yielding something like `'\"(1, 2, 3)\"'`. I munged together a solution that works in my limited testing. Not saying it's the best way to do it, but hopefully it helps illustrate the problem.
